### PR TITLE
feat: add URL store functionality with thumbnail grid

### DIFF
--- a/popup/settings.css
+++ b/popup/settings.css
@@ -7,6 +7,7 @@
 body {
   width: 300px;
   overflow: hidden;
+  min-height: 400px;
 }
 
 .title {
@@ -50,4 +51,56 @@ ul {
 
 #image-url {
   width: 240px;
+}
+
+.image-history {
+  margin: 1em 0.5em;
+}
+
+.image-history h3 {
+  font-size: 16px;
+  margin-bottom: 0.5em;
+  color: #333;
+}
+
+.thumbnail-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.thumbnail {
+  width: 100%;
+  height: 60px;
+  object-fit: cover;
+  border: 2px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: border-color 0.2s, opacity 0.2s;
+}
+
+.thumbnail:hover {
+  border-color: #007acc;
+  opacity: 0.8;
+}
+
+.thumbnail.selected {
+  border-color: #007acc;
+  opacity: 1;
+}
+
+.thumbnail.loading {
+  background-color: #f0f0f0;
+  border-color: #ddd;
+  opacity: 0.5;
+}
+
+.no-history {
+  color: #999;
+  font-style: italic;
+  text-align: center;
+  padding: 1em;
+  font-size: 14px;
 }

--- a/popup/settings.html
+++ b/popup/settings.html
@@ -22,6 +22,12 @@
       <input type="text" id='image-url'>
     </li>
   </ul>
+  <div class="image-history">
+    <h3>Image History</h3>
+    <div id="thumbnail-grid" class="thumbnail-grid">
+      <!-- Thumbnails will be populated here -->
+    </div>
+  </div>
   <script type='module' src='./settings.js'></script>
 </body>
 </html>

--- a/popup/settings.js
+++ b/popup/settings.js
@@ -51,13 +51,139 @@ const changeSize = (e) => {
 
 const changeImage = (e) => {
   console.log(e);
-  const url = {image: e.target.value};
-  sendMessage(url);
-  saveSetting(url);
+  const url = e.target.value;
+  updateCurrentImage(url);
+  if (url && url.trim()) {
+    saveUrlToHistory(url);
+  }
 };
 
 const isValid = (val) => {
   return typeof(val) !== 'undefined' && val !== null && val !== 0;
+}
+
+const updateCurrentImage = (url) => {
+  const imageData = {image: url};
+  sendMessage(imageData);
+  saveSetting(imageData);
+}
+
+const saveUrlToHistory = (url) => {
+  if (!url || !url.trim()) return;
+  
+  const getStorageData = () => {
+    if (window['is_chrome']) {
+      return new Promise((resolve) => {
+        browser.storage.local.get(['image_history'], (result) => {
+          resolve(result);
+        });
+      });
+    } else {
+      return browser.storage.local.get(['image_history']);
+    }
+  };
+  
+  getStorageData().then((result) => {
+    let history = result.image_history || [];
+    
+    // Remove URL if it already exists (to avoid duplicates)
+    history = history.filter(item => item.url !== url);
+    
+    // Add new URL to the beginning of the array
+    history.unshift({
+      url: url,
+      timestamp: Date.now()
+    });
+    
+    // Keep only the last 20 entries
+    if (history.length > 20) {
+      history = history.slice(0, 20);
+    }
+    
+    // Save updated history
+    saveSetting({image_history: history});
+    
+    // Update the thumbnail grid
+    loadImageHistory();
+  });
+}
+
+const selectImageFromHistory = (url) => {
+  // Update the input field
+  const imageInput = document.getElementById('image-url');
+  imageInput.value = url;
+  
+  // Update the current image
+  updateCurrentImage(url);
+  
+  // Update selected state in thumbnails
+  updateThumbnailSelection(url);
+  
+  // Save to history (moves to top)
+  saveUrlToHistory(url);
+}
+
+const updateThumbnailSelection = (selectedUrl) => {
+  const thumbnails = document.querySelectorAll('.thumbnail');
+  thumbnails.forEach(thumbnail => {
+    if (thumbnail.src === selectedUrl) {
+      thumbnail.classList.add('selected');
+    } else {
+      thumbnail.classList.remove('selected');
+    }
+  });
+}
+
+const loadImageHistory = () => {
+  const gridContainer = document.getElementById('thumbnail-grid');
+  
+  const getStorageData = () => {
+    if (window['is_chrome']) {
+      return new Promise((resolve) => {
+        browser.storage.local.get(['image_history'], (result) => {
+          resolve(result);
+        });
+      });
+    } else {
+      return browser.storage.local.get(['image_history']);
+    }
+  };
+  
+  getStorageData().then((result) => {
+    const history = result.image_history || [];
+    
+    // Clear existing thumbnails
+    gridContainer.innerHTML = '';
+    
+    if (history.length === 0) {
+      gridContainer.innerHTML = '<div class="no-history">No image history yet</div>';
+      return;
+    }
+    
+    // Create thumbnails for each URL in history
+    history.forEach((item) => {
+      const thumbnail = document.createElement('img');
+      thumbnail.src = item.url;
+      thumbnail.className = 'thumbnail';
+      thumbnail.title = item.url;
+      
+      // Add click handler
+      thumbnail.addEventListener('click', () => {
+        selectImageFromHistory(item.url);
+      });
+      
+      // Handle loading errors
+      thumbnail.addEventListener('error', () => {
+        thumbnail.style.display = 'none';
+      });
+      
+      gridContainer.appendChild(thumbnail);
+    });
+    
+    // Update selection state
+    const currentUrl = document.getElementById('image-url').value;
+    updateThumbnailSelection(currentUrl);
+  });
 }
 
 if(window['browser'] === undefined) {
@@ -86,6 +212,10 @@ const applySettings = () => {
       sendMessage({is_active: is_active});
       sendMessage({size: size});
       sendMessage({image: image});
+      // Save current image to history if it's valid
+      if (image && image.trim()) {
+        saveUrlToHistory(image);
+      }
     });
   } else {
     let gettingAllStorageItems = browser.storage.local.get(null);
@@ -101,6 +231,10 @@ const applySettings = () => {
       sendMessage({is_active: is_active});
       sendMessage({size: size});
       sendMessage({image: image});
+      // Save current image to history if it's valid
+      if (image && image.trim()) {
+        saveUrlToHistory(image);
+      }
     });
   }
 }
@@ -111,6 +245,7 @@ const init = () => {
   size_input.addEventListener('change', changeSize);
   image_input.addEventListener('change', changeImage, false);
   applySettings();
+  loadImageHistory();
 }
 
 init();


### PR DESCRIPTION
## Summary
- Add image history storage to browser storage
- Display thumbnails in 4-column grid layout
- Enable thumbnail selection to reuse previous images
- Auto-save URLs to history with deduplication
- Support up to 20 stored image URLs
- Add responsive styling for thumbnail grid

## Test plan
- [x] Load extension in browser
- [x] Test URL input saves to history
- [x] Verify thumbnail grid displays properly
- [x] Test thumbnail selection functionality
- [x] Verify deduplication works correctly
- [x] Test responsive grid layout

Addresses #8

🤖 Generated with [Claude Code](https://claude.ai/code)